### PR TITLE
Fix documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PM> Install-Package NBomber.Sinks.InfluxDB
 ```
 
 ### Documentation
-Documentation is located [here](https://nbomber.com/docs/).
+Documentation is located [here](https://nbomber.com/docs/overview/).
 
 ### Contributing
 Would you like to help make NBomber even better? We keep a list of issues that are approachable for newcomers under the [good-first-issue](https://github.com/PragmaticFlow/NBomber.Sinks.InfluxDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) label.


### PR DESCRIPTION
I know the [Influx sink documentation](https://nbomber.com/docs/sinks-influxdb/#api) itself is still skeletal, but I figured that a non-broken link to the main documentation wouldn't hurt.